### PR TITLE
Add customItem label support to getItem

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,53 @@
 # item-api
 Original project by 20kdc. Recovered for general community usage
+
+## Guide for Mod Developers
+So, you want to add custom items into CrossCode? Here's the steps to doing exactly that!
+
+### 1. Patching to the Item Database
+Create a JSON patch file (with the `.json.patch` extension) in the `assets/data` directory of your mod. Within the file, add in code that looks somewhat like this:
+
+```json
+[{
+  "type": "ENTER",
+  "index": "items"
+},{
+  "type": "ADD_ARRAY_ELEMENT",
+  "content":
+  {
+    "order": "this is a number that is used to sort your item in item lists",
+    "customItem": "a label used by item-api to find your custom item, regardless of when the item gets added to the database",
+    "name": {
+      "en_US": "Here's the English translation of your item's name",
+      "langUid": 0
+    },
+    "description": {
+      "en_US": "This is an item description. \\c[3]Here's some fancy yellow text\\c[0]. \\c[2]And some green text\\c[0].",
+      "langUid": 1
+    },
+    "type": "String showing item type. CONS-consumable, EQUIP-equipment, TRADE-trade item, KEY-key item, TOGGLE-add ons",
+    "rarity": "A number determining item rarity. 0-white, 1-bronze, 2-silver, 3-gold, 4-unique, 5-backer",
+    "cost": "A number that shows how much does this item costs to buy. Used in trades and shops alike.",
+    "level": "A number showing the item's level. This is 1 for anything not an equipment",
+    "icon": "String showing item icon. Usually is item-x, with x being anything in [items, sword, helm, belt, shoe, trade, key, toggle].",
+    "effect": {
+      "sheet": "drops",
+      "name": "circle"
+    },
+    "more": "There are more properties that are unique to each of the item types. Take a look at item-database.json to figure them out!"
+  }
+},{
+  "type": "EXIT"
+}]
+```
+
+Assuming you have a patching framework installed (such as the one found in the `simplify` mod), this takes care of the main task of adding items into CrossCode.
+
+### 2. Using Custom Items in Other Data Files
+Given that multiple mods may have added items to the item database in different orders, there is no guarantee that any given custom item will always have the same ID across every CrossCode installation.
+
+This is where `item-api` works its magic. Its key functionality is allowing custom items to have a `customItem` alias that is two-way mapped to the custom item's current ID. To use such a custom item in place of a normal item ID for specifying anything that adds an item, such as enemy item drops or trader offerings, simply use the item's `customItem` alias in place of the usual numeric item ID. If using custom items causes the game to break and crash, please file an issue to this repo, with sufficient details to replicate the bug with.
+
+With that in mind, happy modding, developers!
+
+- Bakafish

--- a/README.md
+++ b/README.md
@@ -48,6 +48,4 @@ Given that multiple mods may have added items to the item database in different 
 
 This is where `item-api` works its magic. Its key functionality is allowing custom items to have a `customItem` alias that is two-way mapped to the custom item's current ID. To use such a custom item in place of a normal item ID for specifying anything that adds an item, such as enemy item drops or trader offerings, simply use the item's `customItem` alias in place of the usual numeric item ID. If using custom items causes the game to break and crash, please file an issue to this repo, with sufficient details to replicate the bug with.
 
-With that in mind, happy modding, developers!
-
-- Bakafish
+With that in mind, happy modding, developers! - Bakafish

--- a/README.md
+++ b/README.md
@@ -48,4 +48,4 @@ Given that multiple mods may have added items to the item database in different 
 
 This is where `item-api` works its magic. Its key functionality is allowing custom items to have a `customItem` alias that is two-way mapped to the custom item's current ID. To use such a custom item in place of a normal item ID for specifying anything that adds an item, such as enemy item drops or trader offerings, simply use the item's `customItem` alias in place of the usual numeric item ID. If using custom items causes the game to break and crash, please file an issue to this repo, with sufficient details to replicate the bug with.
 
-With that in mind, happy modding, developers! - Bakafish
+With that in mind, happy modding, developers! *- Bakafish*

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Create a JSON patch file (with the `.json.patch` extension) in the `assets/data`
   "type": "ADD_ARRAY_ELEMENT",
   "content":
   {
-    "order": "this is a number that is used to sort your item in item lists",
-    "customItem": "a label used by item-api to find your custom item, regardless of when the item gets added to the database",
+    "order": "This is a number that is used to sort your item in item lists",
+    "customItem": "A string label used by item-api to find your custom item, regardless of when the item gets added to the database",
     "name": {
       "en_US": "Here's the English translation of your item's name",
       "langUid": 0

--- a/base-ps.js
+++ b/base-ps.js
@@ -21,18 +21,58 @@ sc.Inventory.inject({
 	addItem: function(a, c, d, e) {
 		var f = window.itemAPI.customItemToId[b];
 		f && (a = f);
-		if (!(a < 0)) {
-			this.items[a] = this.items[a] ? Math.min(this.items[a] + (c | 0), 99) : c | 0;
-			this._addNewItem(a);
-			sc.stats.addMap("items", "total", c);
-			sc.stats.addMap("items", a, c);
-			b.id = a;
-			b.amount = c;
-			b.skip = d;
-			b.cutscene = e;
-			sc.Model.notifyObserver(this, sc.PLAYER_MSG.ITEM_OBTAINED,
-			b)
-		}
-	}
+        if (!(a < 0)) {
+            this.items[a] = this.items[a] ? Math.min(this.items[a] + (c | 0), 99) : c | 0;
+            this._addNewItem(a);
+            sc.stats.addMap("items", "total", c);
+            sc.stats.addMap("items", a, c);
+            b.id = a;
+            b.amount = c;
+            b.skip = d;
+            b.cutscene = e;
+            sc.Model.notifyObserver(this, sc.PLAYER_MSG.ITEM_OBTAINED,
+                b)
+        }
+    },
+    isBuffID: function(b) {
+		return this.getItem(b).isBuff
+    },
+    isEquipID: function(b) {
+		return this.getItem(b).type == sc.ITEMS_TYPES.EQUIP
+    },
+    getItemNameWithIcon: function(b) {
+		b = this.getItem(b);
+		return !b ? "" : "\\i[" + (b.icon + this.getRaritySuffix(b.rarity || 0) || "item-default") + "]" + ig.LangLabel.getText(b.name)
+	},
+	getItemIcon: function(b) {
+		b = this.getItem(b);
+		if (!b)
+			return null;
+		return !b ? "item-default" : "\\i[" + (b.icon + this.getRaritySuffix(b.rarity || 0) || "item-default") + "]"
+	},
+	getItemDescription: function(b) {
+		b = this.getItem(b);
+		return b ? ig.LangLabel.getText(b.description) : ""
+	},
+	getItemRarity: function(b) {
+		b = this.getItem(b);
+		return !b ? null : b.rarity
+	},
+	getItemSubType: function(b) {
+		b = this.getItem(b);
+		return !b ? null : b.equipType
+	},
+	isConsumable: function(b) {
+		b = this.getItem(b);
+		return !b ? false : b.type == sc.ITEMS_TYPES.CONS
+	},
 });
 
+// Devs be violating abstraction barriers I swear to god.
+sc.ItemContent.inject({
+	init: function(b, a) {
+		var c = window.itemAPI.customItemToId[b];
+		c && (b = c);
+		this.parent(b, a);
+	}
+});

--- a/base-ps.js
+++ b/base-ps.js
@@ -17,6 +17,42 @@ sc.Inventory.inject({
 		var c = window.itemAPI.customItemToId[b];
 		c && (b = c);
 		return b < 0 ? null : this.items[b];
+	},
+	/*
+ * CCItemAPI - API for cross-modloader item registration & management
+ * Written starting in 2019 by 20kdc
+ * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide. This software is distributed without any warranty.
+ * You should have received a copy of the CC0 Public Domain Dedication along with this software. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+// Load custom items.
+sc.Inventory.inject({
+	onload: function (a) {
+		this.parent(a);
+		for (var i = 0; i < this.items.length; i++)
+			if (this.items[i])
+				window.itemAPI.onItemRegister(i);
+	},
+	getItem: function (b) {
+		var c = window.itemAPI.customItemToId[b];
+		c && (b = c);
+		return b < 0 ? null : this.items[b];
+	},
+	addItem: function(a, c, d, e) {
+		var f = window.itemAPI.customItemToId[b];
+		f && (a = f);
+		if (!(a < 0)) {
+			this.items[a] = this.items[a] ? Math.min(this.items[a] + (c | 0), 99) : c | 0;
+			this._addNewItem(a);
+			sc.stats.addMap("items", "total", c);
+			sc.stats.addMap("items", a, c);
+			b.id = a;
+			b.amount = c;
+			b.skip = d;
+			b.cutscene = e;
+			sc.Model.notifyObserver(this, sc.PLAYER_MSG.ITEM_OBTAINED,
+			b)
+		}
 	}
 });
 

--- a/base-ps.js
+++ b/base-ps.js
@@ -73,7 +73,7 @@ sc.PlayerModel.inject({
 	getItemAmount: function(a) {
 		var b = window.itemAPI.customItemToId[a];
 		b && (a = b);
-        if (!(a < 0)) return this.items[a] || 0
+        	if (!(a < 0)) return this.items[a] || 0
 	},
 	getItemAmountWithEquip: function(a) {
 		var b = window.itemAPI.customItemToId[a];

--- a/base-ps.js
+++ b/base-ps.js
@@ -107,50 +107,11 @@ sc.PlayerModel.inject({
 	addItem: function(a, c, d, e) {
 		var f = window.itemAPI.customItemToId[a];
 		f && (a = f);
-        if (!(a < 0)) {
-			this.items[a] = this.items[a] ? Math.min(this.items[a] + (c | 0), 99) : c | 0;
-			this._addNewItem(a);
-			sc.stats.addMap("items", "total", c);
-			sc.stats.addMap("items", a, c);
-			b.id = a;
-			b.amount = c;
-			b.skip = d;
-			b.cutscene = e;
-			sc.Model.notifyObserver(this, sc.PLAYER_MSG.ITEM_OBTAINED,
-				b)
-		}
+		this.parent(a, c, d, e);
 	},
 	removeItem: function(a, c, d, e) {
 		var f = window.itemAPI.customItemToId[a];
 		f && (a = f);
-		if (!(a < 0 || c <= 0)) {
-			if (e && this.items[a] < c && sc.inventory.getItem(a).type == sc.ITEMS_TYPES.EQUIP) {
-				if (c - this.items[a] >= 2) {
-					a == this.equip.leftArm && this.setEquipment(sc.MENU_EQUIP_BODYPART.RIGHT_ARM, -1E3);
-					a == this.equip.rightArm && this.setEquipment(sc.MENU_EQUIP_BODYPART.LEFT_ARM, -1E3)
-				} else a == this.equip.rightArm ? this.setEquipment(sc.MENU_EQUIP_BODYPART.RIGHT_ARM, -1E3)
-					: a == this.equip.leftArm && this.setEquipment(sc.MENU_EQUIP_BODYPART.LEFT_ARM, -1E3);
-				a == this.equip.head && this.setEquipment(sc.MENU_EQUIP_BODYPART.HEAD, -1E3);
-				a == this.equip.torso && this.setEquipment(sc.MENU_EQUIP_BODYPART.TORSO, -1E3);
-				a == this.equip.feet && this.setEquipment(sc.MENU_EQUIP_BODYPART.FEET, -1E3)
-			}
-			if (this.items[a]) {
-				c = Math.min(this.items[a], c);
-				this.items[a] = this.items[a] - c;
-				if (this.items[a] <= 0) {
-					this._removeIDFromNewList(a);
-					this.isFavorite(a) && this.updateFavorite(a);
-					if (this.itemToggles[a] && this.itemToggles[a].state) {
-						this.itemToggles[a].state = false;
-						sc.Model.notifyObserver(this, sc.PLAYER_MSG.ITEM_TOGGLED)
-					}
-				}
-				b.id = a;
-				b.amount = c;
-				d || sc.Model.notifyObserver(this, sc.PLAYER_MSG.ITEM_REMOVED, b);
-				return true
-			}
-			return false
-		}
+		this.parent(a, c, d, e);
 	}
 });

--- a/base-ps.js
+++ b/base-ps.js
@@ -19,9 +19,9 @@ sc.Inventory.inject({
 		return b < 0 ? null : this.items[b];
 	},
 	addItem: function(a, c, d, e) {
-		var f = window.itemAPI.customItemToId[b];
+		var f = window.itemAPI.customItemToId[a];
 		f && (a = f);
-        if (!(a < 0)) {
+        	if (!(a < 0)) {
 			this.items[a] = this.items[a] ? Math.min(this.items[a] + (c | 0), 99) : c | 0;
 			this._addNewItem(a);
 			sc.stats.addMap("items", "total", c);

--- a/base-ps.js
+++ b/base-ps.js
@@ -12,6 +12,11 @@ sc.Inventory.inject({
 		for (var i = 0; i < this.items.length; i++)
 			if (this.items[i])
 				window.itemAPI.onItemRegister(i);
+	},
+	getItem: function (b) {
+		var c = window.itemAPI.customItemToId[b];
+		c && (b = c);
+		return b < 0 ? null : this.items[b];
 	}
 });
 

--- a/base-ps.js
+++ b/base-ps.js
@@ -22,17 +22,17 @@ sc.Inventory.inject({
 		var f = window.itemAPI.customItemToId[b];
 		f && (a = f);
         if (!(a < 0)) {
-            this.items[a] = this.items[a] ? Math.min(this.items[a] + (c | 0), 99) : c | 0;
-            this._addNewItem(a);
-            sc.stats.addMap("items", "total", c);
-            sc.stats.addMap("items", a, c);
-            b.id = a;
-            b.amount = c;
-            b.skip = d;
-            b.cutscene = e;
-            sc.Model.notifyObserver(this, sc.PLAYER_MSG.ITEM_OBTAINED,
-                b)
-        }
+			this.items[a] = this.items[a] ? Math.min(this.items[a] + (c | 0), 99) : c | 0;
+			this._addNewItem(a);
+			sc.stats.addMap("items", "total", c);
+			sc.stats.addMap("items", a, c);
+			b.id = a;
+			b.amount = c;
+			b.skip = d;
+			b.cutscene = e;
+			sc.Model.notifyObserver(this, sc.PLAYER_MSG.ITEM_OBTAINED,
+				b)
+		}
     },
     isBuffID: function(b) {
 		return this.getItem(b).isBuff
@@ -65,7 +65,7 @@ sc.Inventory.inject({
 	isConsumable: function(b) {
 		b = this.getItem(b);
 		return !b ? false : b.type == sc.ITEMS_TYPES.CONS
-	},
+	}
 });
 
 // Devs be violating abstraction barriers I swear to god.
@@ -74,5 +74,44 @@ sc.ItemContent.inject({
 		var c = window.itemAPI.customItemToId[b];
 		c && (b = c);
 		this.parent(b, a);
+	}
+});
+
+sc.PlayerModel.inject({
+	getItemAmount: function(a) {
+		var b = window.itemAPI.customItemToId[a];
+		b && console.log(`${a} -> ${b}: ${this.items[b]}`);
+		b && (a = b);
+        if (!(a < 0)) return this.items[a] || 0
+    },
+	getItemAmountWithEquip: function(a) {
+		var b = window.itemAPI.customItemToId[a];
+		b && console.log(`(equip) ${a} -> ${b}: ${this.items[b]}`);
+		b && (a = b);
+		if (!(a < 0)) {
+			var b = this.items[a] || 0,
+			c = sc.inventory.getItem(a);
+			if (c.type == sc.ITEMS_TYPES.EQUIP) {
+				var d = -1,
+				e = -1;
+				switch (c.equipType) {
+					case sc.ITEMS_EQUIP_TYPES.HEAD:
+						d = this.equip.head;
+						break;
+					case sc.ITEMS_EQUIP_TYPES.ARM:
+						d = this.equip.leftArm;
+						e = this.equip.rightArm;
+						break;
+					case sc.ITEMS_EQUIP_TYPES.TORSO:
+						d = this.equip.torso;
+						break;
+					case sc.ITEMS_EQUIP_TYPES.FEET:
+						d = this.equip.feet
+				}
+				d >= 0 && d == a && b++;
+				e >= 0 && e == a && b++
+			}
+			return b
+		}
 	}
 });

--- a/base-ps.js
+++ b/base-ps.js
@@ -18,26 +18,6 @@ sc.Inventory.inject({
 		c && (b = c);
 		return b < 0 ? null : this.items[b];
 	},
-	/*
- * CCItemAPI - API for cross-modloader item registration & management
- * Written starting in 2019 by 20kdc
- * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide. This software is distributed without any warranty.
- * You should have received a copy of the CC0 Public Domain Dedication along with this software. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
- */
-
-// Load custom items.
-sc.Inventory.inject({
-	onload: function (a) {
-		this.parent(a);
-		for (var i = 0; i < this.items.length; i++)
-			if (this.items[i])
-				window.itemAPI.onItemRegister(i);
-	},
-	getItem: function (b) {
-		var c = window.itemAPI.customItemToId[b];
-		c && (b = c);
-		return b < 0 ? null : this.items[b];
-	},
 	addItem: function(a, c, d, e) {
 		var f = window.itemAPI.customItemToId[b];
 		f && (a = f);

--- a/base-ps.js
+++ b/base-ps.js
@@ -80,13 +80,11 @@ sc.ItemContent.inject({
 sc.PlayerModel.inject({
 	getItemAmount: function(a) {
 		var b = window.itemAPI.customItemToId[a];
-		b && console.log(`${a} -> ${b}: ${this.items[b]}`);
 		b && (a = b);
-        if (!(a < 0)) return this.items[a] || 0
-    },
+        	if (!(a < 0)) return this.items[a] || 0
+	},
 	getItemAmountWithEquip: function(a) {
 		var b = window.itemAPI.customItemToId[a];
-		b && console.log(`(equip) ${a} -> ${b}: ${this.items[b]}`);
 		b && (a = b);
 		if (!(a < 0)) {
 			var b = this.items[a] || 0,

--- a/storage.js
+++ b/storage.js
@@ -125,8 +125,8 @@ itemAPI.storageProcessors = {
 			}
 		} else if (shadow) {
 			for (var k in shadow) {
-				if (k in itemAPI.customItemToId) {
-					var id = itemAPI.customItemToId[k];
+				if (shadow[k] in itemAPI.customItemToId) {
+					var id = itemAPI.customItemToId[shadow[k]];
 					// This is the complicated bit...
 					if (victim[k] >= 0) {
 						// Conflict. Push the item into main inventory.


### PR DESCRIPTION
`sc.Inventory.getItem` currently only fetches items by ID alone, ignoring whatever custom item labels `item-api` has added. This prevents certain JSON data that define item ids using an "id" instead of "item" property from correctly utilizing `item-api`, which happens in a few cases such as with custom traders. This change fixes that by forcing a lookup of the `customItemToId` map and replacing the ID accordingly if a value is found.