### PR TITLE
Make scad.stats.getMap() work for custom items

### DIFF
--- a/base-ps.js
+++ b/base-ps.js
@@ -123,3 +123,10 @@ sc.PlayerModel.inject({
 		return false;
 	},
 });
+
+sc.StatsModel.inject({
+    getMap: function(b, a) {
+        if(b == "items") {a = window.itemAPI.customItemToId[a] || a}
+        return this.parent(b, a)
+    }
+});


### PR DESCRIPTION
When adding custom items to enemy drops, the item simply will always show as "??????????" in the monster fibula, as sc.stats.getMap("items", itemID) simply expects a numeric ID, not a custom item's ID. According to the game - you never picked up that item at all. In this case, that means that the item would display, again, as a bunch of question marks. This fix should in theory should solve any other issues related to this. 

Before:
![before](https://user-images.githubusercontent.com/49847844/132928243-afd0e1ea-9406-4444-a452-d6d56125b78b.png)
After:
![after](https://user-images.githubusercontent.com/49847844/132928251-7c8a0ed7-9de2-45d2-ba48-4f9c7f2df820.png)
